### PR TITLE
add set around viewkeys

### DIFF
--- a/marv-server/marv/cli.py
+++ b/marv-server/marv/cli.py
@@ -256,7 +256,7 @@ def marv_node_run(ctx, all_nodes, all_filesets, changed_config, rerun,
         if 'fileset' in node:
             ctx.fail("Cannot rerun fileset node.\n"
                      "Use 'marv fileset discard|scan' to discard and rescan a fileset.")
-        unknown = set(node) - app.site.nodes.nodes.viewkeys()
+        unknown = set(node) - set(app.site.nodes.nodes.viewkeys())
         if unknown:
             ctx.fail('Unknown nodes: %s' % ', '.join(sorted(unknown)))
         app.site.node_run(nodes=None if all_nodes else node,


### PR DESCRIPTION
To fix

```
2016-10-13 11:27:50,699 INFO rospy.topics topicmanager initialized
2016-10-13 11:27:51,008 INFO marv._node Registered nodes in order: ['fileset', u'md5', u'bagset_name', u'bagmeta', u'messages', u'camera_frames', u'diag_count', u'fulltext']
2016-10-13 11:27:51,011 WARNING marv._site Unused config sections ['marv']
Traceback (most recent call last):
  File "/home/jihoonl/tools/marv/venv/bin/marv", line 9, in <module>
    load_entry_point('marv-server==2.0.0b1', 'console_scripts', 'marv')()
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/marv/cli.py", line 343, in cli
    marv(auto_envvar_prefix='MARV')
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/jihoonl/tools/marv/venv/local/lib/python2.7/site-packages/marv/cli.py", line 259, in marv_node_run
    unknown = set(node) - app.site.nodes.nodes.viewkeys()
TypeError: unsupported operand type(s) for -: 'set' and 'KeysView'
2016-10-13 11:27:51,012 INFO rospy.core signal_shutdown [atexit]
```
